### PR TITLE
Cleaning up Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,9 @@
+/**
+ * Roads Gruntfile
+ */
 module.exports = function(grunt) {
+  'use strict';
+  require('load-grunt-tasks')(grunt);
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -12,14 +17,14 @@ module.exports = function(grunt) {
         src: ['src/*.js', 'src/components/*.js'],
         dest: 'dist/<%= pkg.name %>.js',
       },
-    }, 
+    },
     concat_css: {
       options: {},
       all: {
-        src: ["src/**/*.css"],
-        dest: "dist/roads.css"
+        src: ['src/**/*.css'],
+        dest: 'dist/roads.css'
       },
-    },       
+    },
     uglify: {
       options: {
         banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
@@ -33,25 +38,25 @@ module.exports = function(grunt) {
       main: {
         files: [
           {
-            src: 'lib/x-tag.js', 
+            src: 'lib/x-tag.js',
             dest: 'examples/master_detail_navigation/lib/x-tag.js'
           },{
-            src: 'dist/<%= pkg.name %>.js', 
+            src: 'dist/<%= pkg.name %>.js',
             dest: 'examples/master_detail_navigation/lib/<%= pkg.name %>.js'
           },{
-            src: 'dist/<%= pkg.name %>.css', 
+            src: 'dist/<%= pkg.name %>.css',
             dest: 'examples/master_detail_navigation/css/<%= pkg.name %>.css'
           },
           {
-            src: 'lib/x-tag.js', 
+            src: 'lib/x-tag.js',
             dest: 'examples/contacts_maintenance/lib/x-tag.js'
           },{
-            src: 'dist/<%= pkg.name %>.js', 
+            src: 'dist/<%= pkg.name %>.js',
             dest: 'examples/contacts_maintenance/lib/<%= pkg.name %>.js'
           },{
-            src: 'dist/<%= pkg.name %>.css', 
+            src: 'dist/<%= pkg.name %>.css',
             dest: 'examples/contacts_maintenance/css/<%= pkg.name %>.css'
-          }          
+          }
         ],
       }
     },
@@ -62,17 +67,11 @@ module.exports = function(grunt) {
           files: ['lib/x-tag.js', 'dist/<%= pkg.name %>.min.js', 'test/**/*spec.js']
         }
       }
-    }        
+    }
   });
-  
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-concat-css');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-karma');
 
   grunt.registerTask('build', ['concat', 'uglify', 'concat_css']);
-
   grunt.registerTask('deploy', ['copy']);
-
+  // Default action for people who'll be running "grunt" from project's folder
+  grunt.registerTask('default', ['build']);
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",
     "karma-firefox-launcher": "^0.1.4",
-    "karma-jasmine": "^0.3.4"
+    "karma-jasmine": "^0.3.4",
+    "load-grunt-tasks": "^3.1.0"
   }
 }


### PR DESCRIPTION
I cleaned up `Gruntfile.js`, deleted manual Grunt task loading and used `load-grunt-tasks` package to automate it. Also, trailling whitespaces at right side of lines was removed - you need to configure better your editor, dude. Doubled quotes was replaced by single quotes, and finally, a default Grunt task was created for people running only `$ grunt` from the project's folder.
